### PR TITLE
Update tests

### DIFF
--- a/CoalaTests/CoAPTcpSerializerFramingTests.swift
+++ b/CoalaTests/CoAPTcpSerializerFramingTests.swift
@@ -89,32 +89,41 @@ struct CoAPTcpSerializerFramingTests {
     #expect(frames.first?.data == payload)
   }
 
-  // MARK: - Characterization of current quirks (documents existing behavior, not a spec)
-
-  @Test("a garbage first byte stalls the reassembly buffer (current behavior)")
-  func garbageFirstByteStallsBuffer() {
-    // Characterization: a leading byte that is not the delimiter (77) is
-    // never skipped nor discarded, so the buffer stalls and every subsequent
-    // valid frame is swallowed too.
+  @Test("a leading non-delimiter byte is skipped and the next frame decodes")
+  func recoversFromLeadingGarbageByte() {
     let serializer = CoAPTcpSerializer()
     let valid = serializer.encodeTcpFrame(
       with: Address(host: "10.0.0.1", port: 5683), data: Data([0x01, 0x02]))
-    #expect(serializer.decodeTcpFrame(with: Data([0x00]) + valid).isEmpty)
-    // Even a further valid frame cannot recover the stream.
-    #expect(serializer.decodeTcpFrame(with: valid).isEmpty)
+    let frames = serializer.decodeTcpFrame(with: Data([0x00]) + valid)
+    #expect(frames.count == 1)
+    #expect(frames.first?.data == Data([0x01, 0x02]))
+    #expect(frames.first?.address == Address(host: "10.0.0.1", port: 5683))
   }
 
-  @Test("a non-IPv4 host corrupts the frame and nothing is decoded (current behavior)")
-  func nonIPv4HostCorruptsFrame() {
-    // Characterization: a non-dotted-quad host serializes to zero IP bytes,
-    // so the header is 4 bytes short. The decoder then consumes port/size/
-    // payload bytes as the IP, mis-reads payload bytes 0x03 0x04 as the size
-    // (0x0304 == 772) and waits forever for payload that never arrives.
+  @Test("garbage bytes with no delimiter are dropped so a later frame decodes")
+  func recoversAfterGarbageOnlyChunk() {
     let serializer = CoAPTcpSerializer()
+    let valid = serializer.encodeTcpFrame(
+      with: Address(host: "10.0.0.2", port: 2222), data: Data([0x09]))
+    #expect(serializer.decodeTcpFrame(with: Data([0x00, 0x01, 0x02])).isEmpty)
+    let frames = serializer.decodeTcpFrame(with: valid)
+    #expect(frames.count == 1)
+    #expect(frames.first?.data == Data([0x09]))
+  }
+
+  @Test("a non-IPv4 host still produces a structurally valid, decodable frame")
+  func nonIPv4HostProducesValidFrame() {
+    // A non-dotted-quad host cannot be represented in the 4-byte IPv4 field,
+    // but the frame must stay structurally intact (4 IP bytes) so it decodes
+    // and the stream does not desync; the address degrades to 0.0.0.0.
+    let serializer = CoAPTcpSerializer()
+    let payload = Data([0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
     let encoded = serializer.encodeTcpFrame(
-      with: Address(host: "localhost", port: 5683),
-      data: Data([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]))
-    #expect(encoded.count == 1 + 0 + 2 + 2 + 6) // IPv4 field is missing entirely
-    #expect(serializer.decodeTcpFrame(with: encoded).isEmpty)
+      with: Address(host: "localhost", port: 5683), data: payload)
+    #expect(encoded.count == 1 + 4 + 2 + 2 + 6) // IPv4 field is always 4 bytes
+    let frames = serializer.decodeTcpFrame(with: encoded)
+    #expect(frames.count == 1)
+    #expect(frames.first?.data == payload)
+    #expect(frames.first?.address.port == 5683)
   }
 }

--- a/CoalaTests/ObservedResourcesRegistryTests.swift
+++ b/CoalaTests/ObservedResourcesRegistryTests.swift
@@ -62,9 +62,7 @@ final class ObservedResourcesRegistryTests: XCTestCase {
     }
 
     private func registryTimer() -> Timer? {
-        guard let registry = registry else { return nil }
-        return Mirror(reflecting: registry).children
-            .first { $0.label == "timer" }?.value as? Timer
+        return registry?.timer
     }
 
     // MARK: - Sequence number dedup

--- a/CoalaTests/ProxyLayerTests.swift
+++ b/CoalaTests/ProxyLayerTests.swift
@@ -26,7 +26,7 @@ class ProxyLayerTests: XCTestCase {
           defer { coala.stop() }
           try proxyLayer.run(coala: coala, message: &proxiedMessage, toAddress: &destination)
         } catch {
-          XCTAssert(false)
+          XCTFail("outbound proxy run should not throw: \(error)")
         }
         XCTAssertNotNil(proxiedMessage.getOptions(.uriPath).first)
         XCTAssertNotNil(proxiedMessage.getOptions(.uriQuery).first)
@@ -35,7 +35,7 @@ class ProxyLayerTests: XCTestCase {
         XCTAssertEqual(destination, proxyAddress)
     }
 
-    func testProxyError() {
+    func testProxyError() throws {
         let peer = Address(host: "peer.cloud", port: 42)
         let proxyAddress = Address(host: "proxy.cloud", port: 55)
 
@@ -47,18 +47,13 @@ class ProxyLayerTests: XCTestCase {
         let proxyLayer = ProxyLayer()
         var from = proxyAddress
         var ack: CoAPMessage?
-        do {
-            let coala = try Coala(transport: .udp(port: 0))
-            defer { coala.stop() }
-            try proxyLayer.run(coala: coala,
-                               message: &proxiedMessage,
-                               fromAddress: &from,
-                               ack: &ack)
-        } catch {
-            XCTAssert(true)
-            return
-        }
-        XCTAssert(false)
+        let coala = try Coala(transport: .udp(port: 0))
+        defer { coala.stop() }
+        // An inbound message carrying a proxyUri option must be rejected.
+        XCTAssertThrowsError(try proxyLayer.run(coala: coala,
+                                                message: &proxiedMessage,
+                                                fromAddress: &from,
+                                                ack: &ack))
     }
 
 }

--- a/CoalaTests/SecuredSessionTest.swift
+++ b/CoalaTests/SecuredSessionTest.swift
@@ -11,27 +11,23 @@ import XCTest
 
 class SecuredSessionTests: XCTestCase {
 
-    func testDuplex() {
+    func testDuplex() throws {
         let session1 = SecuredSession(incoming: false)
         let session2 = SecuredSession(incoming: true)
-        try? session1.start(peerPublicKey: session2.publicKey)
-        try? session2.start(peerPublicKey: session1.publicKey)
+        try session1.start(peerPublicKey: session2.publicKey)
+        try session2.start(peerPublicKey: session1.publicKey)
         let plainText = "The quick, brown fox jumps over a lazy dog.".data
         let counter: UInt16 = 1000
-        let aead1 = session1.aead!
-        let aead2 = session2.aead!
-        do {
-            let cipher1 = try aead1.seal(plainText: plainText, counter: counter)
-            let plain2 = try aead2.open(cipherText: cipher1, counter: counter)
-            XCTAssertEqual(plainText, plain2)
-            let cipher2 = try aead2.seal(plainText: plainText, counter: counter)
-            let plain1 = try aead1.open(cipherText: cipher2, counter: counter)
-            XCTAssertEqual(plainText, plain1)
-            XCTAssertNotEqual(cipher1, cipher2)
-        } catch let error {
-            print(error)
-            XCTAssert(false)
-        }
+        let aead1 = try XCTUnwrap(session1.aead)
+        let aead2 = try XCTUnwrap(session2.aead)
+
+        let cipher1 = try aead1.seal(plainText: plainText, counter: counter)
+        let plain2 = try aead2.open(cipherText: cipher1, counter: counter)
+        XCTAssertEqual(plainText, plain2)
+        let cipher2 = try aead2.seal(plainText: plainText, counter: counter)
+        let plain1 = try aead1.open(cipherText: cipher2, counter: counter)
+        XCTAssertEqual(plainText, plain1)
+        XCTAssertNotEqual(cipher1, cipher2)
     }
 
 }

--- a/CoalaTests/SecurityLayerTests.swift
+++ b/CoalaTests/SecurityLayerTests.swift
@@ -37,12 +37,7 @@ final class SecurityLayerTests: XCTestCase {
     // MARK: - Helpers
 
     private func pendingMessages() -> [CoAPMessage] {
-        guard let layer = layer,
-              let pool = Mirror(reflecting: layer).children
-                .first(where: { $0.label == "pendingMessages" })?
-                .value as? Synchronized<[CoAPMessage]>
-        else { return [] }
-        return pool.value
+        return layer?.pendingMessages.value ?? []
     }
 
     /// Polls until `condition` is true or the timeout elapses.

--- a/Source/CoAPTcpSerializer.swift
+++ b/Source/CoAPTcpSerializer.swift
@@ -17,7 +17,11 @@ final class CoAPTcpSerializer {
 
     public func encodeTcpFrame(with address: Address, data: Data) -> Data {
         let delimeterData = Data(delimeterByte)
-        let ipData = Data(address.host.split(separator: ".").compactMap { UInt8($0) })
+        // The IPv4 field is a fixed 4 bytes. A host that is not a dotted quad
+        // (e.g. "localhost") cannot be represented, so fall back to 0.0.0.0
+        // rather than emitting a short header that desyncs the decoder.
+        let octets = address.host.split(separator: ".").compactMap { UInt8($0) }
+        let ipData = Data(octets.count == 4 ? octets : [0, 0, 0, 0])
         let portData = Data(UInt16(address.port).byteArrayLittleEndian)
         let sizeData = Data(UInt16(data.count).byteArrayLittleEndian)
         let passedData = delimeterData + ipData + portData + sizeData + data
@@ -28,9 +32,20 @@ final class CoAPTcpSerializer {
         buffer.append(data)
 
         var frames = [Frame]()
-        var pos = 0
 
-        while !buffer.isEmpty && buffer.readBytesAt(&pos, length: 1) == delimeterByte {
+        while !buffer.isEmpty {
+            // Resync: if the stream is misaligned (corruption or a dropped byte),
+            // drop leading bytes up to the next delimiter instead of stalling the
+            // buffer forever. A buffer with no delimiter at all is pure garbage.
+            guard let delimiterIndex = buffer.firstIndex(of: delimeterByte[0]) else {
+                buffer.removeAll()
+                return frames
+            }
+            if delimiterIndex != 0 {
+                buffer.removeSubrange(0..<delimiterIndex)
+            }
+
+            var pos = 1 // consume the delimiter byte
             guard let ipBytes = buffer.readBytesIfPossible(pos: &pos, length: 4),
                   let portBytes = buffer.readBytesIfPossible(pos: &pos, length: 2),
                   let sizeBytes = buffer.readBytesIfPossible(pos: &pos, length: 2)
@@ -50,8 +65,6 @@ final class CoAPTcpSerializer {
 
             frames.append(.init(address: address, data: coapData))
             buffer.removeSubrange(0..<pos)
-
-            pos = 0
         }
         return frames
     }

--- a/Source/ObservedResourcesRegistry.swift
+++ b/Source/ObservedResourcesRegistry.swift
@@ -24,7 +24,7 @@ struct ObservedResource {
 class ObservedResourcesRegistry {
 
     private var tokenToResource = [CoAPToken: ObservedResource]()
-    private var timer: Timer?
+    private(set) var timer: Timer?
     var expirationRandomDelay = 5...15
 
     func resource(forToken token: CoAPToken) -> ObservedResource? {

--- a/Source/ResourceDiscovery.swift
+++ b/Source/ResourceDiscovery.swift
@@ -62,7 +62,7 @@ public class ResourceDiscovery {
         message.onResponse = { result in
             switch result {
             case let .message(message, from):
-              responses.value[from] = message
+              responses.mutate { $0[from] = message }
 
             case .error:
               break

--- a/Source/SecurityLayer.swift
+++ b/Source/SecurityLayer.swift
@@ -26,7 +26,7 @@ final class SecurityLayer: InLayer {
 
     private var securedSessionPool = Synchronized(value: [SecuredSessionKey: SecuredSession]())
     private var proxySecurityIdPool = Synchronized(value: [Address: UInt]())
-    private var pendingMessages = Synchronized(value: [CoAPMessage]())
+    private(set) var pendingMessages = Synchronized(value: [CoAPMessage]())
 
     enum SecurityLayerError: Error {
         case sessionNotEstablished
@@ -140,7 +140,7 @@ final class SecurityLayer: InLayer {
             )
 
             let session = SecuredSession(incoming: true)
-            securedSessionPool.value[sessionKey] = session
+            securedSessionPool.mutate { $0[sessionKey] = session }
             try session.start(peerPublicKey: payload.data)
             var response = CoAPMessage(ackTo: message, from: fromAddress, code: .content)
             response.setOption(.handshakeType, value: 2)
@@ -166,7 +166,7 @@ extension SecurityLayer: OutLayer {
                       coala: Coala,
                       andSendMessage message: CoAPMessage) {
         let session = SecuredSession(incoming: false)
-        securedSessionPool.value[sessionKey] = session
+        securedSessionPool.mutate { $0[sessionKey] = session }
         performHandshake(
             coala: coala,
             session: session,
@@ -176,12 +176,12 @@ extension SecurityLayer: OutLayer {
         ) { [weak self, weak coala] error in
             if let error = error {
                 self?.failPendingMessages(toAddress: toAddress, withError: error)
-                self?.securedSessionPool.value.removeValue(forKey: sessionKey)
+                self?.securedSessionPool.mutate { $0.removeValue(forKey: sessionKey) }
             } else if let coala = coala {
                 self?.sendPendingMessages(toAddress: toAddress, usingCoala: coala)
             }
         }
-        pendingMessages.value.append(message)
+        pendingMessages.mutate { $0.append(message) }
     }
 
     func run(coala: Coala, message: inout CoAPMessage, toAddress: inout Address) throws {
@@ -192,7 +192,7 @@ extension SecurityLayer: OutLayer {
                 proxySecurityId = existingProxyId
             } else {
                 proxySecurityId = UInt(arc4random())
-                proxySecurityIdPool.value[toAddress] = proxySecurityId
+                proxySecurityIdPool.mutate { $0[toAddress] = proxySecurityId }
             }
         }
 
@@ -215,7 +215,7 @@ extension SecurityLayer: OutLayer {
         }
 
         guard let aead = session.aead else {
-            pendingMessages.value.append(message)
+            pendingMessages.mutate { $0.append(message) }
             throw SecurityLayerError.handshakeInProgress
         }
 
@@ -271,7 +271,7 @@ extension SecurityLayer: OutLayer {
                     proxyAddress: message.proxyViaAddress,
                     proxySecurityId: self?.getProxySecurityId(from: message)
                 )
-                self?.securedSessionPool.value[sessionKey] = session
+                self?.securedSessionPool.mutate { $0[sessionKey] = session }
                 peerKey = payload.data
 
             case .error(let error):
@@ -304,7 +304,7 @@ extension SecurityLayer: OutLayer {
         for message in pendingMessages.value.filter({ $0.address == toAddress }) {
             performingBlock(message)
         }
-        pendingMessages.value = pendingMessages.value.filter({ $0.address != toAddress })
+        pendingMessages.mutate { $0.removeAll { $0.address == toAddress } }
     }
 
     func failPendingMessages(toAddress: Address, withError: Error) {

--- a/Source/Synchronized.swift
+++ b/Source/Synchronized.swift
@@ -10,10 +10,14 @@ final public class Synchronized<T> {
   /// Private value. Use `public` `value` computed property (or `reader` and `writer` methods)
   /// for safe, thread-safe access to this underlying value.
   private var _value: T
-  /// Private reader-write synchronization queue
-  private let queue = DispatchQueue(label: Bundle.main.bundleIdentifier! + ".synchronized",
-                                    qos: .default,
-                                    attributes: .concurrent)
+  /// A plain mutex guards every access. A dispatch queue was avoided on
+  /// purpose: `queue.sync` blocks the calling thread, which deadlocks when
+  /// invoked from Swift Testing's cooperative thread pool, and the old async
+  /// barrier setter made writes visible only later (forcing tests to poll).
+  /// A lock keeps reads and writes synchronous and immediately visible, with
+  /// no dependency on `Bundle.main.bundleIdentifier`.
+  private let lock = NSLock()
+
   /// Create `Synchronized` object
   ///
   /// - Parameter value: The initial value to be synchronized.
@@ -23,34 +27,44 @@ final public class Synchronized<T> {
 
   /// A threadsafe variable to set and get the underlying object
   public var value: T {
-    get { return queue.sync { _value } }
-    set { queue.async(flags: .barrier) { self._value = newValue } }
+    get {
+      lock.lock()
+      defer { lock.unlock() }
+      return _value
+    }
+    set {
+      lock.lock()
+      _value = newValue
+      lock.unlock()
+    }
   }
 
-  /// A "reader" method to allow thread-safe, read-only concurrent access to the underlying object.
+  /// A "reader" method to allow thread-safe, read-only access to the underlying object.
   ///
   /// - Warning: If the underlying object is a reference type, you are responsible for making sure you
   ///            do not mutating anything. If you stick with value types (`struct` or primitive types),
   ///            this will be enforced for you.
   public func reader<U>(_ block: (T) -> U) -> U {
-    return queue.sync { block(_value) }
+    lock.lock()
+    defer { lock.unlock() }
+    return block(_value)
   }
 
-  /// A "writer" method to allow thread-safe write with barrier to the underlying object
-  public func writer(_ block: @escaping (inout T) -> Void) {
-    queue.async(flags: .barrier) {
-      block(&self._value)
-    }
+  /// A "writer" method to allow thread-safe write to the underlying object
+  public func writer(_ block: (inout T) -> Void) {
+    lock.lock()
+    defer { lock.unlock() }
+    block(&_value)
   }
 
-  /// Atomic read-modify-write. The entire `block` runs under one barrier, so
+  /// Atomic read-modify-write. The entire `block` runs under the lock, so
   /// compound mutations (`dict[key] = x`, `dict[key]?.field += 1`,
   /// `dict.removeValue(forKey:)`) are race-free, unlike `value[...] = ...`
   /// which is a non-atomic get-then-set.
   @discardableResult
   public func mutate<R>(_ block: (inout T) -> R) -> R {
-    return queue.sync(flags: .barrier) {
-      return block(&self._value)
-    }
+    lock.lock()
+    defer { lock.unlock() }
+    return block(&_value)
   }
 }


### PR DESCRIPTION
decodeTcpFrame's loop guard exited the moment the leading byte was not the delimiter (77) and never dropped it, so one corrupt or dropped byte wedged the reassembly buffer permanently and swallowed every later frame. Skip leading bytes up to the next delimiter (clearing the buffer when none is present) so the stream recovers. Two regression tests cover leading-garbage and garbage-only-chunk recovery.

Always emit a 4-byte IPv4 field in TCP frames

encodeTcpFrame derived the IP field from the dotted-quad host, so a non-IPv4 host such as "localhost" produced zero IP bytes and a frame four bytes short. The decoder then read port/size/payload bytes as the IP, mis-parsed the size, and waited forever for payload that never arrived. Emit exactly four bytes, falling back to 0.0.0.0 when the host is not a dotted quad, so the frame stays parseable.

Read Coala test state via @testable access, not Mirror reflection

SecurityLayerTests.pendingMessages() and ObservedResourcesRegistryTests .registryTimer() looked the properties up by string label through Mirror, so renaming either property would silently return []/nil and turn the count/nil assertions into vacuous passes. Widen the two properties from private to private(set) and read them directly, so a rename is now a compile error instead.

Assert failures loudly in ProxyLayer and SecuredSession tests

ProxyLayerTests used XCTAssert(false)/XCTAssert(true): a socket-bind failure in Coala(transport:) was misreported as "proxy failed" and the error path only proved *something* threw. Use XCTFail with the error and XCTAssertThrowsError. SecuredSessionTest swallowed handshake errors with try? and force-unwrapped aead!, crashing the whole run on failure; make the test throwing and XCTUnwrap the sessions instead.

Back Synchronized with a lock instead of a dispatch queue

The concurrent queue had three problems: its label force-unwrapped Bundle.main.bundleIdentifier (crash in bundle-less contexts); the value setter was an async barrier, so writes became visible only later and tests had to poll; and queue.sync blocks the caller, which wedges when called from Swift Testing's cooperative thread pool. Replace it with an NSLock so every access is synchronous, immediately visible, and free of the cooperative-pool deadlock. Public API is unchanged; the existing concurrent-mutate lost-update tests still pass.

Make Synchronized dictionary/array updates atomic via mutate

SecurityLayer and ResourceDiscovery mutated shared Synchronized state with value[key] = ... / value.append(...) / value = value.filter(...), each a non-atomic get-then-set: two concurrent callers could read the same snapshot and lose one update (dropped session, lost pending message, missing discovery response). Route every compound mutation through mutate so the read-modify-write runs under a single lock; pure lookups keep using value.